### PR TITLE
Enable per-rank afk kick limits (#3648)

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/ISettings.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/ISettings.java
@@ -191,7 +191,11 @@ public interface ISettings extends IConf {
 
     long getAutoAfk();
 
-    long getAutoAfkKick();
+    long getAutoAfkKick(User user);
+
+    long getAutoAfkKick(String set);
+
+    Set<String> getAfkLimits();
 
     boolean getFreezeAfkPlayers();
 

--- a/Essentials/src/main/java/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Settings.java
@@ -943,8 +943,28 @@ public class Settings implements net.ess3.api.ISettings {
     }
 
     @Override
-    public long getAutoAfkKick() {
-        return config.getLong("auto-afk-kick", -1);
+    public long getAutoAfkKick(final User user) {
+        long limit = -1;
+        final Set<String> limitList = getAfkLimits();
+        if (limitList != null) {
+            for (String set : limitList) {
+                if (user.isAuthorized("essentials.auto-afk-kick." + set)) {
+                    limit = getAutoAfkKick(set);
+                }
+            }
+        }
+        return limit;
+    }
+
+    @Override
+    public long getAutoAfkKick(final String set) {
+        return config.getLong("auto-afk-kick." + set, config.getLong("auto-afk-kick.default", -1));
+    }
+
+    @Override
+    public Set<String> getAfkLimits() {
+        final ConfigurationSection section = config.getConfigurationSection("auto-afk-kick");
+        return section == null ? null : section.getKeys(false);
     }
 
     @Override

--- a/Essentials/src/main/java/com/earth2me/essentials/User.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/User.java
@@ -674,7 +674,7 @@ public class User extends UserData implements Comparable<User>, IMessageRecipien
             return;
         }
 
-        final long autoafkkick = ess.getSettings().getAutoAfkKick();
+        final long autoafkkick = ess.getSettings().getAutoAfkKick(this);
         if (autoafkkick > 0
             && lastActivity > 0 && (lastActivity + (autoafkkick * 1000)) < System.currentTimeMillis()
             && !isAuthorized("essentials.kick.exempt")


### PR DESCRIPTION
### Information
This PR closes #3648.

### Details
Server admins can now edit their config.yml files to include afk kick ranks, which will allow different players to remain afk for different lengths of time before being kicked.

**Environments tested:**

    CraftBukkit 1.16.4 (macOS, Java 15.0.1)
